### PR TITLE
feat: add hot reload for python 🔥

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.9-slim-buster
 
 WORKDIR /usr/src/app
 
+RUN apt update
+RUN apt install procps -y
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD [ "python", "./main.py" ]
+CMD [ "python", "./hot_reload.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       - ./:/app
 
   player_home_01:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -51,8 +51,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_02:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -68,8 +68,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_03:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -85,8 +85,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_04:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -102,8 +102,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_05:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -119,8 +119,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_06:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -136,8 +136,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_07:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -153,8 +153,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_08:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -170,8 +170,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_09:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -187,8 +187,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_10:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -204,8 +204,8 @@ services:
       - BOT_GRPC_URL=game_server:5000
 
   player_home_11:
-    image: python:3.9-slim-buster
-    command: ["python", "main.py" ]
+    build: .
+    command: ["python", "hot_reload.py" ]
     working_dir: /usr/src/app
     volumes:
       - ./:/usr/src/app
@@ -232,6 +232,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
 
   player_away_02:
     image: lugobots/the-dummies-go:latest
@@ -245,6 +246,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
 
   player_away_03:
     image: lugobots/the-dummies-go:latest
@@ -258,6 +260,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_04:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -270,6 +273,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_05:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -282,6 +286,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_06:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -294,6 +299,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_07:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -306,6 +312,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_08:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -318,6 +325,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_09:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -330,6 +338,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_10:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -342,6 +351,7 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
   player_away_11:
     image: lugobots/the-dummies-go:latest
     depends_on:
@@ -354,4 +364,5 @@ services:
       - BOT_TEAM=away
       - BOT_GRPC_URL=game_server:5000
       - BOT_GRPC_INSECURE=true
+    restart: on-failure
 

--- a/hot_reload.py
+++ b/hot_reload.py
@@ -1,0 +1,57 @@
+import subprocess
+import os
+import time
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+# Define the command to start your server
+server_command = "python main.py"
+
+# Define the directory to watch for changes
+watched_directory = "./"
+
+# Define a flag to check if the server is running
+server_running = False
+
+
+# Function to start the server
+def start_server():
+    global server_running
+    if not server_running:
+        print("Starting the server...")
+        subprocess.Popen(server_command, shell=True)
+        server_running = True
+
+
+# Function to stop the server
+def stop_server():
+    global server_running
+    if server_running:
+        print("Stopping the server...")
+        os.system("pkill -f main.py")
+        server_running = False
+
+
+# Define an event handler for file changes
+class ServerReloadHandler(FileSystemEventHandler):
+    def on_modified(self, event):
+        if event.src_path.endswith(".py"):
+            print(f"Detected changes in {event.src_path}")
+            stop_server()
+            start_server()
+
+
+# Create an observer to watch the directory
+observer = Observer()
+event_handler = ServerReloadHandler()
+observer.schedule(event_handler, path=watched_directory, recursive=True)
+observer.start()
+
+try:
+    start_server()  # Start the server initially
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    observer.stop()
+
+observer.join()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from my_bot import MyBot
 import lugo4py
 import lugo4py.mapper as mapper
+import signal
 
 from concurrent.futures import ThreadPoolExecutor
 from settings import PLAYER_INITIAL_POSITIONS, MAPPER_COLS, MAPPER_ROWS
@@ -21,16 +22,23 @@ if __name__ == "__main__":
     mapper = mapper.Mapper(MAPPER_COLS, MAPPER_ROWS, config.get_bot_team_side())
 
     # Our bot strategy defines our bot initial position based on its number
-    initialRegion = mapper.get_region(PLAYER_INITIAL_POSITIONS[config.get_bot_number()]['Col'],
-                                      PLAYER_INITIAL_POSITIONS[config.get_bot_number()]['Row'])
+    initialRegion = mapper.get_region(
+        PLAYER_INITIAL_POSITIONS[config.get_bot_number()]["Col"],
+        PLAYER_INITIAL_POSITIONS[config.get_bot_number()]["Row"],
+    )
 
     lugo_client = lugo4py.NewClientFromConfig(config, initialRegion.get_center())
 
-    my_bot = MyBot(config.get_bot_team_side(),
-                   config.get_bot_number(), initialRegion.get_center(), mapper)
+    my_bot = MyBot(
+        config.get_bot_team_side(),
+        config.get_bot_number(),
+        initialRegion.get_center(),
+        mapper,
+    )
 
     def on_join():
         print("Bot is connected to the server")
 
     executor = ThreadPoolExecutor()
+    signal.signal(signal.SIGINT, lambda: executor.shutdown())
     lugo_client.play_as_bot(executor, my_bot, on_join)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-lugo4py==0.0.9
 grpcio==1.51.1
 grpcio-tools==1.51.1
+lugo4py==0.0.9
 protobuf==4.21.12
+watchdog==3.0.0


### PR DESCRIPTION
This adds a **hot reload** feature to the `the-dummies-py` template 🔥

Super useful for trying out new things without having to restarting all the containers!

When a `.py` file changes inside the folder, the bots will temporarily exit and re-enter, without stopping the match.

The way it achieves this is by running a `hot_reload.py` that will reload `main.py` whenever a change is detected, instead of running `main.py` directly.

